### PR TITLE
Add support for newer Django versions

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -7,7 +7,6 @@ from django.utils.translation import ugettext_lazy as _
 from cms.models import CMSPlugin
 
 from filer.fields.file import FilerFileField
-from filer.utils.compatibility import python_2_unicode_compatible
 
 from cmsplugin_filer_utils import FilerPluginManager
 from djangocms_attributes_field.fields import AttributesField
@@ -15,7 +14,6 @@ from djangocms_attributes_field.fields import AttributesField
 from .conf import settings
 
 
-@python_2_unicode_compatible
 class FilerFile(CMSPlugin):
     """
     Plugin for storing any type of file.

--- a/cmsplugin_filer_folder/models.py
+++ b/cmsplugin_filer_folder/models.py
@@ -5,12 +5,10 @@ from django.db import models
 from cms.models import CMSPlugin
 from django.utils.translation import ugettext_lazy as _
 from filer.fields.folder import FilerFolderField
-from filer.utils.compatibility import python_2_unicode_compatible
 from .conf import settings
 from cmsplugin_filer_utils import FilerPluginManager
 
 
-@python_2_unicode_compatible
 class FilerFolder(CMSPlugin):
     """
     Plugin for storing any type of Folder.

--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -7,7 +7,6 @@ from django.utils.translation import ugettext_lazy as _
 from filer.fields.file import FilerFileField
 from filer.fields.image import FilerImageField
 from filer.models import ThumbnailOption  # NOQA
-from filer.utils.compatibility import python_2_unicode_compatible
 
 from cms.models import CMSPlugin
 from cms.models.fields import PageField
@@ -17,7 +16,6 @@ from djangocms_attributes_field.fields import AttributesField
 from .conf import settings
 
 
-@python_2_unicode_compatible
 class FilerImage(CMSPlugin):
     LEFT = "left"
     RIGHT = "right"

--- a/cmsplugin_filer_link/models.py
+++ b/cmsplugin_filer_link/models.py
@@ -9,7 +9,6 @@ from cms.models import CMSPlugin
 from cms.models.fields import PageField
 
 from filer.fields.file import FilerFileField
-from filer.utils.compatibility import python_2_unicode_compatible
 
 from djangocms_attributes_field.fields import AttributesField
 
@@ -23,7 +22,6 @@ LINK_STYLES = getattr(settings, "FILER_LINK_STYLES", DEFULT_LINK_STYLES)
 EXCLUDED_KEYS = ['class', 'href', 'target', ]
 
 
-@python_2_unicode_compatible
 class FilerLinkPlugin(CMSPlugin):
     name = models.CharField(_('name'), max_length=255)
     url = models.CharField(_("url"), blank=True, null=True, max_length=2000)

--- a/cmsplugin_filer_teaser/models.py
+++ b/cmsplugin_filer_teaser/models.py
@@ -3,12 +3,10 @@ from django.db import models
 from cms.models import CMSPlugin
 from cms.models.fields import PageField
 from filer.fields.image import FilerImageField
-from filer.utils.compatibility import python_2_unicode_compatible
 from .conf import settings
 from cmsplugin_filer_utils import FilerPluginManager
 
 
-@python_2_unicode_compatible
 class FilerTeaser(CMSPlugin):
     """
     A Teaser

--- a/cmsplugin_filer_video/models.py
+++ b/cmsplugin_filer_video/models.py
@@ -6,11 +6,9 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from filer.fields.file import FilerFileField
 from filer.fields.image import FilerImageField
-from filer.utils.compatibility import python_2_unicode_compatible
 from os.path import basename
 
 
-@python_2_unicode_compatible
 class FilerVideo(CMSPlugin):
     # player settings
     movie = FilerFileField(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     install_requires=[
-        "Django >= 1.8",
+        "Django >= 2.0",
         "django-filer >= 1.2.0",
 
         "django-cms >= 3.1",


### PR DESCRIPTION
Remove Python 2 decorators and set required Django version to 2.0 > where Python 2.7 support is dropped.